### PR TITLE
fix: an error with linux executable property

### DIFF
--- a/scripts/on_env_start.sh
+++ b/scripts/on_env_start.sh
@@ -40,6 +40,6 @@ cp sd-ui-files/scripts/bootstrap.sh scripts/
 cp sd-ui-files/scripts/start.sh .
 cp sd-ui-files/scripts/developer_console.sh .
 
-./scripts/on_sd_start.sh
+bash ./scripts/on_sd_start.sh
 
 read -p "Press any key to continue"


### PR DESCRIPTION
fixes an error during docker container building: scripts/on_env_start.sh: line 43: ./scripts/on_sd_start.sh: Permission denied